### PR TITLE
Fix swagger doc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,5 @@ swag init -g cmd/server/main.go -o docs
 
 After running the server access `http://localhost:8080/docs/index.html` to explore the API.
 
+Swagger UI loads the OpenAPI spec from `/docs/swagger.json`. Ensure this file exists after running `swag init`.
+

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -98,7 +98,9 @@ func main() {
 		r.Get("/{id}", ProductHandler.GetProduct)
 	})
 
-	r.Get("/docs/*", httpSwagger.Handler(httpSwagger.URL("http://localhost:8080/docs/doc.json")))
+	// Serve Swagger documentation
+	// Generated docs are named swagger.json by swag
+	r.Get("/docs/*", httpSwagger.Handler(httpSwagger.URL("http://localhost:8080/docs/swagger.json")))
 	// Grupo para usuários autenticados
 	r.Group(func(r chi.Router) {
 		r.Use(jwtauth.Verifier(cfg.TokenAuth))


### PR DESCRIPTION
## Summary
- correct Swagger JSON route to match generated file
- mention swagger.json path in README

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687af13e9938832c9149cf4f8a4b3a28