### PR TITLE
Add missing newline at EOF

### DIFF
--- a/internal/infra/database/user_db.go
+++ b/internal/infra/database/user_db.go
@@ -36,7 +36,6 @@ func (u *UserDb) FindUserById(id string) (*entity.User, error) {
 	return &user, err
 }
 
-
 func (u *UserDb) UpdateUser(user *entity.User) error {
 	return u.DB.Save(user).Error
 }


### PR DESCRIPTION
## Summary
- ensure `internal/infra/database/user_db.go` ends with a newline
- format `internal/infra/database/user_db.go` with gofmt

## Testing
- `gofmt -w internal/infra/database/user_db.go`

------
https://chatgpt.com/codex/tasks/task_e_687af5c9bb38832c9415a03624f8edf9