### PR TITLE
Add seeded users for demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ go run cmd/server/main.go
 ```
 
 When the server starts it performs the database migrations and seeds sample data.
+If the user table is empty, three accounts are created for testing:
+
+- **admin@example.com** / `1234` (role: `admin`)
+- **manager@example.com** / `1234` (role: `manager`)
+- **customer@example.com** / `1234` (role: `customer`)
 
 ### Swagger documentation
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -74,6 +74,7 @@ func main() {
 	// AutoMigrate para criar as tabelas automaticamente
 	db.AutoMigrate(&entity.Role{}, &entity.Product{}, &entity.User{})
 	seed.SeedRoles(db)
+	seed.SeedUsers(db)
 	seed.SeedProducts(db)
 
 	productdb := database.NewProductDB(db)

--- a/internal/infra/database/seeds/user_seed.go
+++ b/internal/infra/database/seeds/user_seed.go
@@ -1,0 +1,59 @@
+package seed
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/mateusfaustino/go-rest-api-III/internal/entity"
+	"github.com/mateusfaustino/go-rest-api-III/internal/infra/database"
+	"gorm.io/gorm"
+)
+
+func SeedUsers(db *gorm.DB) {
+	userDB := database.NewUserDb(db)
+	roleDB := database.NewRoleDB(db)
+
+	// Check if users already exist
+	var count int64
+	if err := db.Model(&entity.User{}).Count(&count).Error; err != nil {
+		log.Printf("Erro ao verificar usuários existentes: %v\n", err)
+		return
+	}
+
+	if count > 0 {
+		fmt.Println("Já existem usuários no banco de dados. Pulando seed...")
+		return
+	}
+
+	// Ensure roles exist
+	roleCustomer, _ := roleDB.FindRoleByName("customer")
+	roleManager, _ := roleDB.FindRoleByName("manager")
+	roleAdmin, _ := roleDB.FindRoleByName("admin")
+
+	users := []struct {
+		name  string
+		email string
+		role  *entity.Role
+	}{
+		{"Customer User", "customer@example.com", roleCustomer},
+		{"Manager User", "manager@example.com", roleManager},
+		{"Admin User", "admin@example.com", roleAdmin},
+	}
+
+	for _, u := range users {
+		if u.role == nil {
+			log.Printf("Role não encontrada para o usuário %s\n", u.email)
+			continue
+		}
+		user, err := entity.NewUser(u.name, u.email, "1234", u.role.ID)
+		if err != nil {
+			log.Printf("Erro ao criar usuário '%s': %v\n", u.email, err)
+			continue
+		}
+		if err := userDB.CreateUser(user); err != nil {
+			log.Printf("Erro ao salvar usuário '%s': %v\n", u.email, err)
+		} else {
+			fmt.Printf("Usuário '%s' criado com sucesso!\n", u.email)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- seed customer, manager and admin users
- update server to run the new seeder
- document sample credentials in README

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687b0086f3cc832c93480cbc71c99485